### PR TITLE
add support for clip.exe when using WSL

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func list(bmarks Bookmarks) {
 func isWSL() bool {
 	ret := false
 	if runtime.GOOS == "linux" {
-		verBytes, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
+		verBytes, err := ioutil.ReadFile(osReleasePath)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Checks if running on WSL, and uses Windows' clip.exe to copy password to clipboard

Solves #1 